### PR TITLE
Allow other mixins to call toJSON, parse, validate

### DIFF
--- a/backbone-nested-types.js
+++ b/backbone-nested-types.js
@@ -81,8 +81,14 @@
         // Passes `options` to each nested type constructor.
         // Hint: Pass `parse:true` to recursively instantiate nested types.
         parse: function (attrs, options) {
-            // Call the mixee's `parse()` first in case some transformations must be applied.
-            attrs = this.constructor.__super__.parse.apply(this, arguments);
+            // Save a reference to the original constructor, then overwrite it with the 
+            // super constructor so that other mixins can override `parse()` in the same way.
+            var originalConstructor = this.constructor;
+            this.constructor = this.constructor.__super__.constructor;
+
+            // Call the mixee's `parse()` to support transformations, then fix the constructor reference.
+            attrs = originalConstructor.__super__.parse.apply(this, arguments);
+            this.constructor = originalConstructor;
 
             // Get the current nested types.
             var nestedTypes = _.result(this, 'nestedTypes') || {};
@@ -112,8 +118,14 @@
         // Serializes attributes defined in `nestedTypes` by using their `toJSON()` method, if provided.
         // Passes `options` to each instance nested `toJSON()`.
         toJSON: function (options) {
-            // Call the mixee's `toJSON()` first in case some transformations must be applied.
-            var json = this.constructor.__super__.toJSON.apply(this, arguments);
+            // Save a reference to the original constructor, then overwrite it with the 
+            // super constructor so that other mixins can override `toJSON()` in the same way.
+            var originalConstructor = this.constructor;
+            this.constructor = this.constructor.__super__.constructor;
+
+            // Call the mixee's `toJSON()` to support transformations, then fix the constructor reference.
+            var json = originalConstructor.__super__.toJSON.apply(this, arguments);
+            this.constructor = originalConstructor;
 
             // Get the current nested types.
             var nestedTypes = _.result(this, 'nestedTypes') || {};
@@ -133,9 +145,15 @@
         // Passes `options` to each nested `validate()` call.
         // Pass the option `validateNested: false` to skip validation of nested models.
         validate: function (attrs, options) {
-            // Calls the mixee's `validate()` first to support recursive validation.
-            var originalValidate = this.constructor.__super__.validate || _.noop,
-                validationError = originalValidate.apply(this, arguments);
+            // Save a reference to the original constructor, then overwrite it with the 
+            // super constructor so that other mixins can override `validate()` in the same way.
+            var originalConstructor = this.constructor;
+            this.constructor = this.constructor.__super__.constructor;
+
+            // Call the mixee's `parse()` to support recursive validation, then fix the constructor reference.
+            var validate = originalConstructor.__super__.validate || _.noop;
+            var validationError = validate.apply(this, arguments);
+            this.constructor = originalConstructor;
 
             // Don't validate nested types if `validateNested: false`.
             if (options && options.validateNested === false) {

--- a/test/backbone-nested-types-test.js
+++ b/test/backbone-nested-types-test.js
@@ -109,6 +109,27 @@ describe('NestedTypeMixin', function () {
             expect(actual).to.eql({ nested: { foo: 'bar' } });
         });
 
+        it('should serialize model using multiple mixins with toJSON calls', function () {
+            var OtherMixin = {
+                toJSON: function() {
+                    return this.constructor.__super__.toJSON.apply(this, arguments);
+                }
+            };
+
+            var MultipleMixinModel = Backbone.Model.extend({
+                toJSON: function() {
+                    return { foo: 'bar' };
+                }
+            }).extend(OtherMixin).extend(NestedTypeMixin);
+
+            var multipleMixinModel = new MultipleMixinModel();
+
+            // act
+            var actual = multipleMixinModel.toJSON();
+
+            expect(actual).to.eql({ foo: 'bar' });
+        });
+
         it('should serialize nested model when nestedTypes is a function', function() {
             var Model = Backbone.Model.extend({
                 defaults: function() {
@@ -466,6 +487,27 @@ describe('NestedTypeMixin', function () {
             }).to.throw(TypeError);
         });
 
+        it('should parse model using multiple mixins with parse calls', function () {
+            var OtherMixin = {
+                parse: function() {
+                    return this.constructor.__super__.parse.apply(this, arguments);
+                }
+            };
+
+            var MultipleMixinModel = Backbone.Model.extend({
+                parse: function() {
+                    return { foo: 'bar' };
+                }
+            }).extend(OtherMixin).extend(NestedTypeMixin);
+
+            var multipleMixinModel = new MultipleMixinModel();
+
+            // act
+            var actual = multipleMixinModel.parse();
+
+            expect(actual).to.eql({ foo: 'bar' });
+        });
+
         it('should parse nested Backbone collection into an instance of the Collection', function () {
             var Collection = Backbone.Collection.extend({
                 model: Backbone.Model.extend()
@@ -685,6 +727,27 @@ describe('NestedTypeMixin', function () {
             mixedModel.validate();
 
             expect(mixedModel.get('myModel').validate.calledOnce).to.be.true;
+        });
+
+        it('should validate model using multiple mixins with validate calls', function () {
+            var OtherMixin = {
+                validate: function() {
+                    return this.constructor.__super__.validate.apply(this, arguments);
+                }
+            };
+
+            var MultipleMixinModel = Backbone.Model.extend({
+                validate: function() {
+                    return 'success';
+                }
+            }).extend(OtherMixin).extend(NestedTypeMixin);
+
+            var multipleMixinModel = new MultipleMixinModel();
+
+            // act
+            var actual = multipleMixinModel.validate();
+
+            expect(actual).to.eql('success');
         });
 
         it('should not throw error when a nested model does not define validate', function () {


### PR DESCRIPTION
By temporarily changing the constructor reference, other mixins on the same model can properly use `__super__` to call super methods.
